### PR TITLE
Add Node.js client in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Currently the following clients are provided.
 * JavaScript contributed by Anastasios Zouzias
 * PHP contributed by Spiros Ioannou
 
+Other clients (not hosted in this repo):
+
+* [Node.js client](https://www.npmjs.com/package/afm-info)
+
 # Contributing
 Contributions in other languages (e.g. Python, Ruby, C++, client-side JavaScript) are
 welcomed.


### PR DESCRIPTION
Hi there,

I came across this repo after Diomidis' presentation at FOSSCOMM 2016. Currently there is a JavaScript example in the repo that shows how to use the gsis service but it's implemented as a web app. So I thought it would be cool if it was implemented also as a node.js lib, so that it can be used in different ways.

I hosted it in the [greecejs/afm-info](https://github.com/greecejs/afm-info) repo and published the package on npm as [afm-info](https://www.npmjs.com/package/afm-info).

Even though the code is not hosted in this repo, I thought you might want to link to other external related projects in the README, so I added a link to it in this repo's README. I also [link back](%28https://github.com/greecejs/afm-info#related%29) from my README :smiley:
